### PR TITLE
Utilisation du .env :wrench:

### DIFF
--- a/.env.recette.exemple
+++ b/.env.recette.exemple
@@ -15,7 +15,8 @@
 # https://symfony.com/doc/current/best_practices.html#use-environment-variables-for-infrastructure-configuration
 
 ###> symfony/framework-bundle ###
-APP_ENV=dev
+APP_ENV=recette
+APP_DEBUG=0
 APP_SECRET=f4de5d0baf9b8fb62b6fe5fb4b2ed5c2
 POSTGRES_DB=flotte
 POSTGRES_USER=flotte_user

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -22,3 +22,8 @@ when@test:
         test: true
         session:
             storage_factory_id: session.storage.factory.mock_file
+
+when@dev:
+    framework:
+        profiler: { collect: true }
+        error_controller: null


### PR DESCRIPTION
dans le .env si je met APP_ENV=DEV
Docker compose up -d
je suis en dev donc j'ai le profiler(la toolbar et les vrais erreur avec le fantôme bouuhh)
docker compose down
Dans le .env si je met APP_ENV=recette
sa va taper sur le .env.recette
Docker compose up -d
je suis en recette docn pas de fantôme et pas de profiler :boom:

Dans le .yaml je dis la meme chose mais en code
